### PR TITLE
Bootstrap ingestion pipeline scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# Anti-G
+# Anti-G Project Blueprint
+
+Anti-G is a multi-repository initiative focused on building a production-grade football match prediction and betting optimization platform. This repository serves as the umbrella project plan that orchestrates the data, modeling, and betting strategy services required for profitable wagering on gambling sites.
+
+## Program Objectives
+
+1. **Predictive Accuracy** – Design machine-learning services that leverage historical performance, squad conditions, contextual metadata (venue, turf, weather, schedule), and circular match information to forecast football match outcomes and derived markets (1X2, BTTS, totals, handicaps).
+2. **Market Exploitation** – Continuously scrape regulated bookmakers, detect mispriced odds, and synthesize betting tickets that maximize risk-adjusted return given bankroll and market constraints.
+3. **Operational Excellence** – Deliver an automated, observable, and secure platform that can be deployed to production-grade infrastructure with CI/CD, feature governance, and compliance guardrails.
+
+## Workstreams & Repository Layout
+
+| Repository | Focus | Key Responsibilities |
+|------------|-------|----------------------|
+| [`repos/data-pipeline`](repos/data-pipeline/README.md) | Data acquisition & quality | Scrape fixtures, results, injuries, player metrics, bookmaker odds; orchestrate ETL, validations, and storage. |
+| [`repos/feature-engineering`](repos/feature-engineering/README.md) | Feature store & analytics | Transform raw data into model-ready datasets, maintain feature catalog, handle circular and contextual signals. |
+| [`repos/prediction-service`](repos/prediction-service/README.md) | Machine learning | Build, train, evaluate, and serve predictive models (classification, probabilistic, simulation-based). |
+| [`repos/betting-optimizer`](repos/betting-optimizer/README.md) | Betting strategy engine | Scrape odds, compare against predicted edges, generate optimal bet combinations per risk profile. |
+| [`repos/platform-infra`](repos/platform-infra/README.md) | Infrastructure & DevOps | Manage infrastructure-as-code, CI/CD, observability, secrets, and MLOps tooling. |
+
+Supporting documentation lives in [`docs/`](docs/) and includes the delivery roadmap, system architecture, and governance processes.
+
+## Delivery Roadmap
+
+See [`docs/roadmap.md`](docs/roadmap.md) for a phased execution plan that covers discovery, MVP delivery, scaling, and optimization milestones.
+
+## Collaboration Guidelines
+
+- Treat each directory under `repos/` as an independent codebase with its own lifecycle, tooling, and deployment target.
+- Use trunk-based development within each repository; adopt feature branches per workstream when collaborating.
+- Enforce automated testing, linting, and data-quality checks through CI pipelines defined in each repo.
+- Follow the documented coding standards and modeling best practices in `docs/` before contributing.
+
+## Next Steps
+
+1. Align stakeholders on roadmap milestones and budget allocation.
+2. Prioritize data acquisition tasks that unlock model prototyping (fixtures, results, injuries, betting odds).
+3. Stand up the data-pipeline repository and implement incremental ingestion jobs.
+4. Deliver an MVP prediction model and calibrate it against bookmaker odds for selected leagues.
+5. Iterate on betting optimization strategies and integrate bankroll management.
+
+For detailed architectural decisions and technology selections, consult [`docs/architecture.md`](docs/architecture.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,94 @@
+# System Architecture & Technical Blueprint
+
+## High-Level Architecture
+
+```
+[Data Sources] ──> [Data Pipeline] ──> [Feature Store] ──> [Prediction Service] ──> [Betting Optimizer] ──> [Delivery Channels]
+    |                  |                   |                    |                        |                      |
+    |                  |                   |                    |                        |                      └─ Reports / Dashboards
+    |                  |                   |                    |                        └─ Ticket API / Portfolio Manager
+    |                  |                   |                    └─ Model Registry / Serving Layer
+    |                  |                   └─ Metadata Catalog / Validation Layer
+    |                  └─ Workflow Orchestrator / Storage
+    └─ Ingestion Adapters / Web Scrapers / APIs
+```
+
+### Core Principles
+- **Modularity**: Isolate scraping, feature engineering, modeling, and optimization to scale independently.
+- **Reproducibility**: Version datasets, features, and models using MLflow/Weights & Biases plus a metadata catalog.
+- **Observability**: Collect logs, metrics, traces, and data-quality alerts across every service.
+- **Compliance**: Maintain audit trails for data sourcing and betting decisions; enforce access controls and encryption.
+
+## Components
+
+### Data Pipeline (`repos/data-pipeline`)
+- **Sources**: League fixtures/results APIs, Opta/StatsBomb data, weather feeds, injury reports, bookmaker odds.
+- **Ingestion**: Mix of REST polling, websocket listeners, and headless browser scrapers with proxy rotation.
+- **Processing**: Orchestrated via Airflow or Dagster, writing bronze→silver→gold layers in cloud storage + data warehouse.
+- **Quality**: Great Expectations or Soda for validation, with alerts to Slack/PagerDuty.
+
+### Feature Engineering (`repos/feature-engineering`)
+- **Feature Layers**: Team form (Elo, rolling xG), player efficiency, squad availability, schedule congestion, venue/turf, referee tendencies.
+- **Circular Features**: Represent seasonality/time-of-day via sin/cos transforms, encode rest cycles and tournament phases.
+- **Serving**: Feast or custom feature store with offline store (Parquet/BigQuery) and online store (Redis/DynamoDB).
+- **Analytics**: Provide notebooks/dashboards for feature discovery and hypothesis testing.
+
+### Prediction Service (`repos/prediction-service`)
+- **Modeling Stack**: Python, scikit-learn, XGBoost, LightGBM, PyTorch for neural nets, PyMC/Stan for Bayesian models.
+- **Targets**: Match outcome probabilities, goal distributions (Poisson/negative binomial), player props.
+- **Evaluation**: Cross-validation by season, calibration curves, Brier/log-loss, profitability vs. implied odds.
+- **Deployment**: MLflow or Sagemaker endpoints, with Dockerized microservices exposing REST/gRPC APIs.
+
+### Betting Optimizer (`repos/betting-optimizer`)
+- **Odds Scraping**: Scrapy/Playwright-based collectors with redundancy across bookmakers.
+- **Edge Engine**: Compare predicted win probabilities vs. odds, account for bookmaker margin (overround) and market liquidity.
+- **Optimization**: Mixed-integer programming (PuLP/OR-Tools) for combinatorial tickets, reinforcement learning for dynamic staking.
+- **Risk Management**: Bankroll allocation (Kelly variants), stop-loss/take-profit rules, compliance logging.
+
+### Platform Infrastructure (`repos/platform-infra`)
+- **IaC**: Terraform modules for networking, compute (EKS/GKE), data warehouse, storage, secrets manager.
+- **CI/CD**: GitHub Actions/GitLab CI pipelines with automated testing, linting, and deployment gates.
+- **Observability**: Prometheus/Grafana, ELK/Opensearch, OpenTelemetry tracing, cost monitoring.
+- **Security**: SSO integration, secret rotation, vulnerability scanning, dependency management.
+
+## Data Management Strategy
+- **Storage**: Raw data in object storage (S3/GCS); structured data in warehouse (Snowflake/BigQuery/Postgres).
+- **Cataloging**: Use DataHub or Amundsen to document datasets, lineage, and ownership.
+- **Versioning**: DVC or LakeFS for dataset version control; Git LFS for large artifacts if required.
+- **Access Controls**: Role-based access with least privilege, encryption at rest and in transit.
+
+## Modeling Best Practices
+- Use hierarchical and contextual models to capture team-level and player-level interactions.
+- Incorporate market-derived priors (implied probabilities) as calibration baselines.
+- Perform backtesting with rolling windows and scenario-based simulations (injuries, schedule congestion).
+- Maintain champion/challenger setup with automated A/B evaluation and fallback mechanisms.
+
+## Betting Strategy Best Practices
+- Quantify edge vs. bookmaker margin before recommending bets.
+- Diversify tickets across leagues and bet types to manage correlation risk.
+- Enforce responsible gambling thresholds and compliance checks per jurisdiction.
+- Integrate alerting for odds movement and limit changes.
+
+## Operational Processes
+- **Incident Response**: On-call rotation, runbooks, postmortems.
+- **Data/Model Governance**: Approval workflows for new data sources and models, documenting assumptions and limitations.
+- **Compliance Audits**: Regular reviews of data sourcing agreements and betting recommendations.
+- **Continuous Improvement**: Feedback loops from bettors, profitability metrics, model drift detection.
+
+## Technology Stack Summary
+
+| Layer | Primary Tools | Alternatives |
+|-------|---------------|--------------|
+| Ingestion | Python, Airflow/Dagster, Playwright/Scrapy | Prefect, Luigi |
+| Storage | S3/GCS, Snowflake/BigQuery/Postgres | Azure Data Lake, Redshift |
+| Feature Store | Feast, Redis, BigQuery | Tecton, custom microservice |
+| Modeling | scikit-learn, XGBoost, PyTorch, MLflow | TensorFlow, CatBoost |
+| Optimization | OR-Tools, PuLP, cvxpy | Pyomo, Gurobi |
+| Serving | FastAPI, gRPC, Docker, Kubernetes | Flask, AWS Lambda |
+| Observability | Prometheus, Grafana, ELK, OpenTelemetry | Datadog, New Relic |
+
+## Future Enhancements
+- Real-time streaming ingestion for in-play betting using Kafka/Kinesis.
+- Computer vision models to process video feeds for player tracking.
+- Automated hedging strategies across exchanges (e.g., Betfair) to manage exposure.
+- Dynamic user personalization for tailored betting recommendations.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,85 @@
+# Delivery Roadmap
+
+This roadmap breaks the Anti-G program into four phases with iterative milestones. Each milestone produces tangible assets (datasets, services, or decision support tools) that unlock value while de-risking later stages.
+
+## Phase 0 – Discovery & Foundations (Weeks 1-4)
+
+### Objectives
+- Define supported competitions, betting markets, and regulatory constraints.
+- Validate data providers (official APIs, open data, injury feeds, odds sources) and negotiate access.
+- Establish governance: security, compliance, data retention, responsible gambling policies.
+
+### Key Deliverables
+- Requirements brief and compliance checklist.
+- Proof-of-concept data ingestion notebooks validating coverage and latency.
+- Infrastructure decision log (cloud provider, orchestration, secret management, database).
+- Hiring or contractor plan for data engineers, ML engineers, quant analysts, and DevOps.
+
+## Phase 1 – Data Platform MVP (Weeks 5-10)
+
+### Objectives
+- Implement automated ingestion for match schedules, historical results, player stats, injuries, weather, and bookmaker odds.
+- Stand up bronze (raw) → silver (validated) → gold (analytical) data layers with metadata and lineage tracking.
+- Deliver analytics-ready datasets to unblock modeling work.
+
+### Key Deliverables
+- Airflow or Dagster pipelines for each data source with monitoring and alerting.
+- Data quality suite covering schema drift, missingness, latency, and outliers.
+- Normalized database schema (e.g., Snowflake/Postgres/BigQuery) and storage policy for raw files.
+- Documentation for data contracts and API usage.
+
+## Phase 2 – Prediction & Evaluation MVP (Weeks 11-18)
+
+### Objectives
+- Build feature pipeline capturing form, efficiency metrics, circular contexts (time-of-season, rest days), weather, and team sheets.
+- Train baseline models (e.g., gradient boosting, probabilistic neural nets, Bayesian models) for primary markets (1X2, over/under, BTTS).
+- Evaluate calibration against bookmaker implied probabilities; identify mispricing windows.
+
+### Key Deliverables
+- Feature store with serving APIs and offline training materialization.
+- Automated experimentation framework with cross-validation, backtesting, and feature importance reporting.
+- Model registry with versioning, metrics, and deployment hooks.
+- Bias and fairness report ensuring adherence to responsible AI standards.
+
+## Phase 3 – Betting Optimization & Ticket Generation (Weeks 19-26)
+
+### Objectives
+- Implement live odds scrapers with rate limiting, captcha mitigation, and compliance logging.
+- Build edge detection service to compare predicted probabilities vs. bookmaker odds, including margin adjustments.
+- Design bankroll management strategies (Kelly, fractional Kelly, risk parity) and staking rules.
+- Generate bet slips optimized for ROI, turnover requirements, and risk exposure.
+
+### Key Deliverables
+- Odds ingestion microservice with persistence and alerting.
+- Optimization engine (linear/integer programming or heuristic search) for ticket construction.
+- Simulation suite for scenario analysis and stress testing.
+- Web dashboard or API delivering recommended bets with audit trail.
+
+## Phase 4 – Scale, Automation & Continuous Improvement (Weeks 27+)
+
+### Objectives
+- Harden infrastructure with autoscaling, CI/CD, observability, and failover.
+- Introduce reinforcement learning or dynamic programming for in-play betting strategies.
+- Expand market coverage (player props, corners, cards) and multi-sport support.
+- Monitor profitability, model drift, and compliance; iterate based on feedback loops.
+
+### Key Deliverables
+- Full production monitoring stack (metrics, logs, traces) and anomaly detection alerts.
+- Automated retraining and deployment workflows triggered by data freshness or performance thresholds.
+- Post-deployment review cadence with KPIs, profitability dashboards, and compliance sign-off.
+- Backlog of R&D initiatives prioritized by expected ROI.
+
+## Cross-Cutting Workstreams
+
+- **Data Governance**: Data catalog, access controls, anonymization where necessary.
+- **MLOps**: Reproducible training pipelines, artifact tracking, experiment management.
+- **Risk & Compliance**: Adherence to gambling regulations, anti-money laundering checks, user protection mechanisms.
+- **Product & UX**: Feedback from bettors, interface design for dashboards or APIs, localization.
+
+## Milestone Acceptance Criteria
+
+Each phase completes when:
+1. All defined deliverables are deployed to staging or production environments.
+2. Documentation and runbooks are published and peer reviewed.
+3. Success metrics (accuracy, latency, uptime, ROI targets) meet agreed thresholds.
+4. Stakeholders sign off during governance review.

--- a/repos/betting-optimizer/README.md
+++ b/repos/betting-optimizer/README.md
@@ -1,0 +1,55 @@
+# Betting Optimizer Repository
+
+## Mission
+Leverage predictive insights and live bookmaker data to build an automated betting recommendation engine that maximizes risk-adjusted returns while adhering to regulatory constraints.
+
+## Scope
+- **Odds Acquisition**: Scrape and aggregate prices, limits, and market availability across targeted bookmakers.
+- **Edge Calculation**: Compare model-derived probabilities vs. odds to detect value bets, accounting for overround and vig removal.
+- **Portfolio Optimization**: Construct single and multi-leg tickets using optimization techniques (integer programming, heuristics, simulation) aligned with bankroll strategies.
+- **Risk Controls**: Enforce staking rules, exposure limits, and compliance checks (jurisdiction, responsible gambling policies).
+- **Delivery**: Provide APIs, alerting systems, and dashboards for recommended bets and performance tracking.
+
+## Proposed Stack
+- **Languages**: Python for optimization, Node.js or Python for API delivery.
+- **Scraping**: Playwright, Selenium, or bookmaker APIs with proxy & captcha handling.
+- **Optimization**: OR-Tools, PuLP, cvxpy, or Pyomo; Monte Carlo simulations for scenario testing.
+- **APIs/UI**: FastAPI backend, React/Next.js or Streamlit for dashboards.
+- **Monitoring**: Custom telemetry for bet execution, ROI tracking, and alerting.
+
+## Directory Structure
+```
+src/
+  odds/
+    collectors/
+    normalizers/
+  edge/
+    calculators/
+    margin_adjustment/
+  optimizer/
+    ticket_builders/
+    bankroll/
+    simulations/
+  delivery/
+    api/
+    notifications/
+    dashboard/
+  utils/
+config/
+  bookmakers/
+  optimization/
+notebooks/
+  strategy_research/
+```
+
+## Initial Milestones
+1. Build odds collection service for two primary bookmakers with redundancy and latency monitoring.
+2. Implement edge calculation pipeline referencing prediction-service outputs.
+3. Prototype bankroll management strategies (Kelly, fixed stake) and evaluate historical performance.
+4. Develop optimization engine producing recommended singles and accumulator tickets.
+5. Create reporting dashboard to visualize ROI, hit rate, and exposure by league/market.
+
+## Compliance & Ethics
+- Log all scraping activity and adhere to bookmaker terms of service; integrate kill switch for legal escalations.
+- Provide transparent rationale for each bet recommendation (probabilities, edge, stake suggestion).
+- Enforce configurable betting limits aligned with responsible gambling guidelines.

--- a/repos/data-pipeline/.gitignore
+++ b/repos/data-pipeline/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+artifacts/

--- a/repos/data-pipeline/README.md
+++ b/repos/data-pipeline/README.md
@@ -1,0 +1,72 @@
+# Data Pipeline Repository
+
+## Mission
+Build resilient ingestion and transformation workflows that consolidate all football and betting-related data sources into trusted datasets for downstream modeling and optimization.
+
+## Scope
+- **Source Integration**: Fixtures, historical results, player stats, injuries/suspensions, team news, weather, betting odds, and market limits.
+- **Ingestion Modes**: REST APIs, websocket feeds, headless browser scraping, CSV ingestion, third-party webhooks.
+- **Processing**: Batch (hourly/daily) and near-real-time pipelines orchestrated via Airflow/Dagster.
+- **Data Lakehouse**: Bronze (raw), silver (validated), gold (aggregated) layers with schema evolution support.
+- **Quality Assurance**: Automated validation suites, anomaly detection, latency SLAs, data contract enforcement.
+
+## Proposed Stack
+- **Language**: Python 3.11+
+- **Orchestration**: Apache Airflow or Dagster
+- **Storage**: S3/GCS for files, Snowflake/BigQuery/Postgres for structured tables
+- **Validation**: Great Expectations, Soda Core
+- **Testing**: pytest, dbt tests for transformations
+- **Infrastructure**: Dockerized tasks, Kubernetes/ECS deployment
+
+## Directory Structure
+```
+src/
+  ingestion/
+    adapters/        # Source-specific connectors (APIs, scrapers)
+    schedules/       # Airflow DAGs or Dagster jobs
+  processing/
+    transformations/ # dbt or Pandas/SQL transformations
+    validations/     # Data quality suites
+  utils/             # Shared helpers (logging, retry logic)
+config/
+  credentials/       # Encrypted secrets references (Vault/SM)
+  schemas/           # JSON schemas for validation
+notebooks/
+  exploration/       # Data profiling and exploratory analysis
+```
+
+## Initial Milestones
+1. Finalize list of priority leagues, markets, and bookmakers.
+2. Stand up ingestion DAGs for fixtures/results and odds for top leagues.
+3. Implement bronze→silver normalization with schema tests.
+4. Automate quality checks and alerting for data latency/missingness.
+5. Document data contracts and publish sample datasets for modeling team.
+
+## Key Risks & Mitigations
+- **Website Blocking**: Employ rotating proxies, captcha solvers, and fall back to paid APIs.
+- **Schema Drift**: Implement contract tests with automated alerts and fallback parsers.
+- **Latency**: Prioritize asynchronous scraping and incremental updates to meet pre-match windows.
+- **Compliance**: Maintain legal review of scraping activities, respect robots.txt where applicable.
+
+## Development Setup
+1. Create and activate a virtual environment targeting Python 3.10+.
+2. Install the project in editable mode (append `.[dev]` if you prefer to work with pytest):
+   ```bash
+   pip install -e .
+   ```
+3. Execute the unit test suite:
+   ```bash
+   python -m unittest discover -s tests
+   ```
+
+## Quickstart
+The repository ships with a thin ingestion pipeline that demonstrates how we will normalize raw
+fixtures into curated JSON Lines artifacts. To try it locally:
+
+```bash
+cd repos/data-pipeline
+python -m data_pipeline.pipeline
+```
+
+By default the pipeline will read from the sample dataset in `tests/data/sample_matches.json` and
+write the normalized matches to `./artifacts/matches.jsonl`.

--- a/repos/data-pipeline/pyproject.toml
+++ b/repos/data-pipeline/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "anti-g-data-pipeline"
+version = "0.1.0"
+description = "Core ingestion and normalization utilities for the Anti-G football betting dataset."
+authors = [{name = "Anti-G Engineering"}]
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7.4"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/repos/data-pipeline/src/data_pipeline/__init__.py
+++ b/repos/data-pipeline/src/data_pipeline/__init__.py
@@ -1,0 +1,11 @@
+"""Anti-G data pipeline package."""
+
+from .models import MatchRecord, PipelineError, PipelineResult
+from .pipeline import IngestionPipeline
+
+__all__ = [
+    "MatchRecord",
+    "PipelineError",
+    "PipelineResult",
+    "IngestionPipeline",
+]

--- a/repos/data-pipeline/src/data_pipeline/ingestion/__init__.py
+++ b/repos/data-pipeline/src/data_pipeline/ingestion/__init__.py
@@ -1,0 +1,6 @@
+"""Ingestion utilities."""
+
+from .adapters.base import SourceAdapter
+from .adapters.static import StaticJSONAdapter
+
+__all__ = ["SourceAdapter", "StaticJSONAdapter"]

--- a/repos/data-pipeline/src/data_pipeline/ingestion/adapters/base.py
+++ b/repos/data-pipeline/src/data_pipeline/ingestion/adapters/base.py
@@ -1,0 +1,16 @@
+"""Base interfaces for ingestion adapters."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, Mapping
+
+
+class SourceAdapter(ABC):
+    """Abstract interface for raw data providers."""
+
+    @abstractmethod
+    def load(self) -> Iterable[Mapping[str, object]]:
+        """Yield raw records from an upstream source."""
+
+        raise NotImplementedError

--- a/repos/data-pipeline/src/data_pipeline/ingestion/adapters/static.py
+++ b/repos/data-pipeline/src/data_pipeline/ingestion/adapters/static.py
@@ -1,0 +1,40 @@
+"""Static file based adapters for local development and testing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from .base import SourceAdapter
+
+
+class StaticJSONAdapter(SourceAdapter):
+    """Loads match data from a JSON document on disk."""
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+
+    @property
+    def path(self) -> Path:
+        """Return the backing file path."""
+
+        return self._path
+
+    def load(self) -> Iterable[Mapping[str, object]]:
+        """Yield items from the JSON document."""
+
+        with self._path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+
+        if isinstance(payload, Mapping):
+            yield payload
+            return
+
+        if isinstance(payload, Sequence):
+            for item in payload:
+                if isinstance(item, Mapping):
+                    yield item
+            return
+
+        raise ValueError(f"Unsupported JSON payload in {self._path}")

--- a/repos/data-pipeline/src/data_pipeline/models.py
+++ b/repos/data-pipeline/src/data_pipeline/models.py
@@ -1,0 +1,58 @@
+"""Core domain models for the Anti-G data pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+
+@dataclass(frozen=True)
+class MatchRecord:
+    """Normalized representation of a football match."""
+
+    match_id: str
+    competition: str
+    season: str
+    kickoff: datetime
+    home_team: str
+    away_team: str
+    home_score: Optional[int]
+    away_score: Optional[int]
+    venue: Optional[str]
+    surface: Optional[str]
+    weather: Optional[str]
+    home_form: Optional[float]
+    away_form: Optional[float]
+    extras: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def to_serializable_dict(self) -> Dict[str, Any]:
+        """Return a JSON-ready dictionary."""
+
+        payload = asdict(self)
+        payload["kickoff"] = self.kickoff.isoformat()
+        return payload
+
+
+@dataclass(frozen=True)
+class PipelineError:
+    """Represents an error encountered while running a pipeline."""
+
+    identifier: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """Summary emitted after the ingestion pipeline completes."""
+
+    processed: int
+    failed: int
+    errors: List[PipelineError]
+    output_locations: Iterable[str]
+
+    @property
+    def success(self) -> bool:
+        """Return ``True`` when all records were processed successfully."""
+
+        return self.failed == 0

--- a/repos/data-pipeline/src/data_pipeline/pipeline.py
+++ b/repos/data-pipeline/src/data_pipeline/pipeline.py
@@ -1,0 +1,104 @@
+"""Ingestion orchestration."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Sequence
+
+from .ingestion import SourceAdapter
+from .models import MatchRecord, PipelineError, PipelineResult
+from .processing.transformations import MatchTransformer
+from .processing.validations import BasicMatchValidator
+from .storage import JsonLinesSink
+
+
+class IngestionPipeline:
+    """Minimal ingestion pipeline for transforming and persisting matches."""
+
+    def __init__(
+        self,
+        adapter: SourceAdapter,
+        transformer: MatchTransformer | None = None,
+        validators: Sequence[BasicMatchValidator] | None = None,
+        sink: JsonLinesSink | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._adapter = adapter
+        self._transformer = transformer or MatchTransformer()
+        self._validators = list(validators or [BasicMatchValidator()])
+        self._sink = sink or JsonLinesSink("./artifacts/matches.jsonl")
+        self._logger = logger or logging.getLogger(__name__)
+
+    def run(self) -> PipelineResult:
+        processed = 0
+        failed = 0
+        errors: List[PipelineError] = []
+        output_locations: List[str] = []
+
+        with self._sink as sink:
+            output_locations.append(str(sink.path))
+            for raw in self._adapter.load():
+                identifier = _extract_identifier(raw)
+                try:
+                    match = self._transformer.transform(raw)
+                    self._apply_validators(match)
+                    sink.write(match)
+                    processed += 1
+                except Exception as exc:  # pragma: no cover - logging path
+                    failed += 1
+                    reason = str(exc)
+                    errors.append(PipelineError(identifier=identifier, reason=reason))
+                    self._logger.warning("Failed to process record %s: %s", identifier, reason)
+
+        return PipelineResult(
+            processed=processed,
+            failed=failed,
+            errors=errors,
+            output_locations=output_locations,
+        )
+
+    def _apply_validators(self, match: MatchRecord) -> None:
+        for validator in self._validators:
+            validator.validate(match)
+
+
+def _extract_identifier(raw: object) -> str:
+    if isinstance(raw, dict):
+        for key in ("id", "match_id", "uuid"):
+            value = raw.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return "<unknown>"
+
+
+def main() -> None:  # pragma: no cover - exercised manually
+    """Run the sample ingestion pipeline."""
+
+    from .ingestion import StaticJSONAdapter
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    project_root = Path(__file__).resolve().parents[3]
+    sample_path = project_root / "tests" / "data" / "sample_matches.json"
+    if not sample_path.exists():
+        raise SystemExit(
+            "Sample dataset not found. Expected to locate tests/data/sample_matches.json"
+        )
+
+    pipeline = IngestionPipeline(adapter=StaticJSONAdapter(sample_path))
+    result = pipeline.run()
+
+    logging.info(
+        "Processed %s records (%s failed)",
+        result.processed,
+        result.failed,
+    )
+    logging.info("Outputs written to: %s", ", ".join(result.output_locations))
+    if result.failed:
+        for error in result.errors:
+            logging.error("%s -> %s", error.identifier, error.reason)
+
+
+if __name__ == "__main__":  # pragma: no cover - module CLI
+    main()

--- a/repos/data-pipeline/src/data_pipeline/processing/__init__.py
+++ b/repos/data-pipeline/src/data_pipeline/processing/__init__.py
@@ -1,0 +1,1 @@
+"""Processing components."""

--- a/repos/data-pipeline/src/data_pipeline/processing/transformations/__init__.py
+++ b/repos/data-pipeline/src/data_pipeline/processing/transformations/__init__.py
@@ -1,0 +1,5 @@
+"""Transformation utilities."""
+
+from .match import MatchTransformer
+
+__all__ = ["MatchTransformer"]

--- a/repos/data-pipeline/src/data_pipeline/processing/transformations/match.py
+++ b/repos/data-pipeline/src/data_pipeline/processing/transformations/match.py
@@ -1,0 +1,150 @@
+"""Transformation logic for football match data."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping, MutableMapping, Optional
+
+from ...models import MatchRecord
+
+
+class MatchTransformer:
+    """Convert raw payloads from various feeds into :class:`MatchRecord`."""
+
+    def __init__(self, default_competition: str | None = None) -> None:
+        self._default_competition = default_competition
+
+    def transform(self, raw: Mapping[str, object]) -> MatchRecord:
+        """Normalize a raw record.
+
+        Parameters
+        ----------
+        raw:
+            Mapping returned by a :class:`~data_pipeline.ingestion.SourceAdapter`.
+        """
+
+        record = _as_mutable(raw)
+        match_id = _require_str(record, {"id", "match_id"})
+        competition = self._extract_competition(record)
+        season = str(record.get("season") or "")
+        kickoff = self._parse_datetime(record)
+
+        home_team, home_score, home_form = self._extract_team(record, "home")
+        away_team, away_score, away_form = self._extract_team(record, "away")
+
+        venue = _nested_str(record, ["venue", "name"])
+        surface = _nested_str(record, ["venue", "surface"])
+        weather = record.get("weather")
+        extras = {
+            "source": record.get("source"),
+            "referee": record.get("referee"),
+            "round": record.get("round"),
+        }
+
+        return MatchRecord(
+            match_id=match_id,
+            competition=competition,
+            season=season,
+            kickoff=kickoff,
+            home_team=home_team,
+            away_team=away_team,
+            home_score=home_score,
+            away_score=away_score,
+            venue=venue,
+            surface=surface,
+            weather=weather if isinstance(weather, str) else None,
+            home_form=home_form,
+            away_form=away_form,
+            extras={k: v for k, v in extras.items() if v is not None},
+        )
+
+    def _extract_competition(self, record: MutableMapping[str, object]) -> str:
+        competition = record.get("competition")
+        if isinstance(competition, Mapping):
+            name = competition.get("name")
+            if isinstance(name, str) and name:
+                return name
+        if isinstance(competition, str) and competition:
+            return competition
+        if self._default_competition:
+            return self._default_competition
+        raise ValueError("Missing competition in raw record")
+
+    def _extract_team(
+        self, record: MutableMapping[str, object], key: str
+    ) -> tuple[str, Optional[int], Optional[float]]:
+        team = record.get(key)
+        if not isinstance(team, Mapping):
+            raise ValueError(f"Missing {key} team block")
+
+        name = team.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"Missing {key} team name")
+
+        score = _safe_int(team.get("score"))
+        form = _safe_float(team.get("form"))
+        return name, score, form
+
+    def _parse_datetime(self, record: MutableMapping[str, object]) -> datetime:
+        raw_value = record.get("kickoff") or record.get("date")
+        if not isinstance(raw_value, str):
+            raise ValueError("Kickoff timestamp missing")
+
+        normalized = raw_value.replace("Z", "+00:00")
+        try:
+            return datetime.fromisoformat(normalized)
+        except ValueError as exc:
+            raise ValueError(f"Invalid kickoff timestamp: {raw_value}") from exc
+
+
+def _as_mutable(raw: Mapping[str, object]) -> MutableMapping[str, object]:
+    if isinstance(raw, MutableMapping):
+        return raw
+    return dict(raw)
+
+
+def _nested_str(record: Mapping[str, object], path: list[str]) -> Optional[str]:
+    cursor: object = record
+    for segment in path:
+        if not isinstance(cursor, Mapping):
+            return None
+        cursor = cursor.get(segment)
+    return cursor if isinstance(cursor, str) else None
+
+
+def _require_str(record: Mapping[str, object], keys: set[str]) -> str:
+    for key in keys:
+        value = record.get(key)
+        if isinstance(value, str) and value:
+            return value
+    raise ValueError(f"Missing string identifier, checked keys: {sorted(keys)}")
+
+
+def _safe_int(value: object) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int,)):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _safe_float(value: object) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None

--- a/repos/data-pipeline/src/data_pipeline/processing/validations/__init__.py
+++ b/repos/data-pipeline/src/data_pipeline/processing/validations/__init__.py
@@ -1,0 +1,5 @@
+"""Validation utilities."""
+
+from .basic import BasicMatchValidator
+
+__all__ = ["BasicMatchValidator"]

--- a/repos/data-pipeline/src/data_pipeline/processing/validations/basic.py
+++ b/repos/data-pipeline/src/data_pipeline/processing/validations/basic.py
@@ -1,0 +1,39 @@
+"""Simple guard-rail validations for normalized matches."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from ...models import MatchRecord
+
+
+class BasicMatchValidator:
+    """Minimal validation rules before persisting matches."""
+
+    def __init__(self, earliest_year: int = 2000) -> None:
+        self._earliest_year = earliest_year
+
+    def validate(self, match: MatchRecord) -> None:
+        """Raise :class:`ValueError` if the record violates basic assumptions."""
+
+        if match.home_team == match.away_team:
+            raise ValueError("Home and away teams must differ")
+
+        if match.kickoff.tzinfo is None:
+            raise ValueError("Kickoff timestamp must include timezone info")
+
+        min_dt = datetime(self._earliest_year, 1, 1, tzinfo=timezone.utc)
+        if match.kickoff < min_dt:
+            raise ValueError("Kickoff predates allowed window")
+
+        if match.home_score is not None and match.home_score < 0:
+            raise ValueError("Home score cannot be negative")
+
+        if match.away_score is not None and match.away_score < 0:
+            raise ValueError("Away score cannot be negative")
+
+        if match.home_form is not None and not 0 <= match.home_form <= 1:
+            raise ValueError("Home form must be within [0, 1]")
+
+        if match.away_form is not None and not 0 <= match.away_form <= 1:
+            raise ValueError("Away form must be within [0, 1]")

--- a/repos/data-pipeline/src/data_pipeline/storage/__init__.py
+++ b/repos/data-pipeline/src/data_pipeline/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Output sinks for pipeline artifacts."""
+
+from .jsonl import JsonLinesSink
+
+__all__ = ["JsonLinesSink"]

--- a/repos/data-pipeline/src/data_pipeline/storage/jsonl.py
+++ b/repos/data-pipeline/src/data_pipeline/storage/jsonl.py
@@ -1,0 +1,43 @@
+"""JSON Lines sink for persisting normalized matches."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+from ..models import MatchRecord
+
+
+class JsonLinesSink:
+    """Write records to a JSON Lines document."""
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+        self._handle = None
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def __enter__(self) -> "JsonLinesSink":  # noqa: D401 - context manager semantics
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self._path.open("w", encoding="utf-8")
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:  # noqa: D401
+        if self._handle:
+            self._handle.close()
+            self._handle = None
+
+    def write(self, record: MatchRecord) -> None:
+        if self._handle is None:
+            raise RuntimeError("Sink must be entered before writing")
+        payload = record.to_serializable_dict()
+        json.dump(payload, self._handle, ensure_ascii=False)
+        self._handle.write("\n")
+
+    def flush_all(self, records: Iterable[MatchRecord]) -> None:
+        with self as sink:
+            for record in records:
+                sink.write(record)

--- a/repos/data-pipeline/tests/data/sample_matches.json
+++ b/repos/data-pipeline/tests/data/sample_matches.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "EPL2023-001",
+    "competition": {"name": "Premier League"},
+    "season": "2023/2024",
+    "kickoff": "2024-02-18T16:30:00Z",
+    "venue": {"name": "Emirates Stadium", "surface": "Grass"},
+    "home": {"name": "Arsenal", "score": 2, "form": 0.82},
+    "away": {"name": "Liverpool", "score": 1, "form": 0.78},
+    "weather": "Cloudy"
+  },
+  {
+    "id": "BADMATCH",
+    "competition": {"name": "Premier League"},
+    "season": "2023/2024",
+    "home": {"name": "Chelsea"},
+    "away": {"name": "Chelsea"}
+  }
+]

--- a/repos/data-pipeline/tests/test_pipeline.py
+++ b/repos/data-pipeline/tests/test_pipeline.py
@@ -1,0 +1,97 @@
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from data_pipeline.ingestion import StaticJSONAdapter  # noqa: E402
+from data_pipeline.pipeline import IngestionPipeline  # noqa: E402
+from data_pipeline.processing.transformations import MatchTransformer  # noqa: E402
+from data_pipeline.processing.validations import BasicMatchValidator  # noqa: E402
+from data_pipeline.storage import JsonLinesSink  # noqa: E402
+from data_pipeline.models import MatchRecord  # noqa: E402
+
+
+class IngestionPipelineTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sample_file = ROOT / "tests" / "data" / "sample_matches.json"
+
+    def test_pipeline_processes_and_writes_jsonl(self) -> None:
+        adapter = StaticJSONAdapter(self.sample_file)
+        transformer = MatchTransformer()
+        validator = BasicMatchValidator()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sink_path = Path(tmpdir) / "matches.jsonl"
+            sink = JsonLinesSink(sink_path)
+            pipeline = IngestionPipeline(
+                adapter=adapter,
+                transformer=transformer,
+                validators=[validator],
+                sink=sink,
+            )
+
+            result = pipeline.run()
+
+            self.assertEqual(result.processed, 1)
+            self.assertEqual(result.failed, 1)
+            self.assertFalse(result.success)
+            self.assertIn(str(sink_path), result.output_locations)
+
+            with sink_path.open("r", encoding="utf-8") as handle:
+                lines = handle.readlines()
+
+        self.assertEqual(len(lines), 1)
+        record = json.loads(lines[0])
+        self.assertEqual(record["match_id"], "EPL2023-001")
+        self.assertEqual(record["home_team"], "Arsenal")
+        self.assertEqual(record["away_team"], "Liverpool")
+        self.assertEqual(record["home_score"], 2)
+        self.assertEqual(record["away_score"], 1)
+        self.assertIn("kickoff", record)
+
+    def test_validator_rejects_duplicate_teams(self) -> None:
+        validator = BasicMatchValidator()
+        match = MatchRecord(
+            match_id="TEST-1",
+            competition="Test League",
+            season="2024",
+            kickoff=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            home_team="Same Team",
+            away_team="Same Team",
+            home_score=1,
+            away_score=1,
+            venue=None,
+            surface=None,
+            weather=None,
+            home_form=0.5,
+            away_form=0.5,
+        )
+        with self.assertRaises(ValueError):
+            validator.validate(match)
+
+    def test_transformer_uses_default_competition(self) -> None:
+        transformer = MatchTransformer(default_competition="Liga MX")
+        raw = {
+            "id": "LIGA-100",
+            "season": "2024",
+            "kickoff": "2024-03-14T02:00:00+00:00",
+            "home": {"name": "Club America", "form": "0.7"},
+            "away": {"name": "Pumas", "form": 0.6},
+        }
+
+        match = transformer.transform(raw)
+
+        self.assertEqual(match.competition, "Liga MX")
+        self.assertEqual(match.home_form, 0.7)
+        self.assertEqual(match.away_form, 0.6)
+        self.assertEqual(match.home_score, None)
+        self.assertIsNotNone(match.kickoff.tzinfo)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/repos/feature-engineering/README.md
+++ b/repos/feature-engineering/README.md
@@ -1,0 +1,50 @@
+# Feature Engineering Repository
+
+## Mission
+Deliver a governed feature store that transforms raw football and betting data into enriched, contextualized features ready for predictive modeling and real-time inference.
+
+## Scope
+- **Feature Creation**: Build team-level, player-level, and market-level features capturing form, efficiency, injuries, travel, rest, time-of-day, venue characteristics, and bookmaker signals.
+- **Circular & Temporal Modeling**: Encode periodic information (seasonality, match time, rest cycles) using sinusoidal and circular statistics.
+- **Feature Management**: Register features with lineage, owners, freshness SLAs, and validation rules.
+- **Serving**: Provide both offline datasets for training and online feature APIs for low-latency scoring.
+- **Governance**: Track feature usage, monitor drift, and enforce naming conventions and documentation standards.
+
+## Proposed Stack
+- **Processing**: Pandas, Polars, Spark (for scale), SQL/dbt for warehouse transformations.
+- **Feature Store**: Feast or custom metadata layer backed by Redis/BigQuery/Postgres.
+- **Experimentation**: JupyterLab, Databricks, or notebooks with papermill for reproducibility.
+- **Validation**: EvidentlyAI for drift, Great Expectations for feature quality.
+
+## Directory Structure
+```
+src/
+  feature_pipelines/
+    team_form/
+    player_availability/
+    contextual/
+  serving/
+    online/
+    offline/
+  monitoring/
+    drift_checks/
+    data_quality/
+config/
+  feature_specs/   # YAML definitions with metadata & owners
+  schedules/
+notebooks/
+  research/
+  feature_reports/
+```
+
+## Initial Milestones
+1. Define feature contracts and taxonomy (naming, owners, refresh cadence).
+2. Build team form & efficiency pipeline (rolling xG, Elo, shot quality).
+3. Incorporate injury and lineup data with probabilistic availability modeling.
+4. Engineer contextual features (rest days, travel distance, pitch type, weather).
+5. Publish offline training dataset schema and register features in store.
+
+## Quality & Monitoring
+- Validate feature freshness and null rates before publishing.
+- Compare model feature importance regularly to prune unused features.
+- Track drift metrics and trigger retraining or recalibration when thresholds exceed limits.

--- a/repos/platform-infra/README.md
+++ b/repos/platform-infra/README.md
@@ -1,0 +1,51 @@
+# Platform Infrastructure Repository
+
+## Mission
+Provide reproducible infrastructure-as-code and DevOps tooling to deploy, monitor, and secure all Anti-G services across environments (dev, staging, production).
+
+## Scope
+- **Infrastructure-as-Code**: Define networking, compute, storage, IAM, and secrets management via Terraform modules.
+- **CI/CD**: Centralized pipelines for linting, testing, deployment, and compliance checks across all service repositories.
+- **Observability**: Logging, metrics, tracing, cost monitoring, and incident response automation.
+- **Security & Compliance**: Secret rotation, vulnerability scanning, data retention policies, access controls.
+- **MLOps Enablement**: Shared tooling for model registry, artifact storage, and automated retraining triggers.
+
+## Proposed Stack
+- **Cloud**: AWS (preferred) with support for GCP/Azure alternatives.
+- **Orchestration**: Kubernetes (EKS/GKE), Helm charts, ArgoCD or Flux for GitOps.
+- **CI/CD**: GitHub Actions or GitLab CI with reusable workflows.
+- **Secrets**: AWS Secrets Manager or HashiCorp Vault.
+- **Observability**: Prometheus, Grafana, Loki/ELK, OpenTelemetry collectors.
+
+## Directory Structure
+```
+terraform/
+  environments/
+    dev/
+    staging/
+    prod/
+  modules/
+    networking/
+    compute/
+    data/
+    security/
+ci/
+  github_actions/
+  gitlab/
+ops/
+  monitoring/
+  incident_response/
+  runbooks/
+```
+
+## Initial Milestones
+1. Provision foundational networking, Kubernetes cluster, and managed database/storage resources via Terraform.
+2. Implement CI/CD pipelines with quality gates (linting, tests, security scans) for all repositories.
+3. Deploy centralized observability stack with alerting integrations.
+4. Define secrets management strategy and implement least-privilege IAM roles.
+5. Document deployment runbooks and disaster recovery procedures.
+
+## Governance
+- Follow change-management processes with peer review and automated plan/apply workflows.
+- Maintain configuration drift detection and compliance audits (e.g., AWS Config, Terraform Cloud policy checks).
+- Document architecture decisions (ADRs) and update regularly in the shared `docs/` directory.

--- a/repos/prediction-service/README.md
+++ b/repos/prediction-service/README.md
@@ -1,0 +1,60 @@
+# Prediction Service Repository
+
+## Mission
+Develop, evaluate, and serve high-accuracy football prediction models that estimate probabilities and distributions for markets used in pre-match and in-play betting.
+
+## Scope
+- **Model Portfolio**: Classification (1X2), regression (goal totals), probabilistic models (Poisson, negative binomial), Bayesian hierarchical models, ensemble techniques.
+- **Training Pipelines**: Automated workflows that pull curated features, perform preprocessing, training, hyperparameter optimization, and artifact packaging.
+- **Evaluation**: Backtesting, calibration analysis, profitability vs. bookmaker odds, uncertainty estimation, and explainability (SHAP/feature importance).
+- **Serving**: Real-time inference API, batch scoring jobs, model registry integration, A/B testing framework.
+- **Governance**: Model documentation, ethical considerations, compliance with responsible gambling requirements.
+
+## Proposed Stack
+- **Languages**: Python 3.11+, optional R modules for advanced stats.
+- **Libraries**: scikit-learn, XGBoost, LightGBM, CatBoost, PyTorch, PyMC/Stan, Optuna for HPO.
+- **Workflow**: MLflow for experiment tracking and model registry, Prefect/Airflow for orchestration.
+- **Serving**: FastAPI or BentoML microservices packaged with Docker, deployed on Kubernetes/ECS.
+- **Monitoring**: EvidentlyAI, WhyLabs, custom dashboards for calibration and drift.
+
+## Directory Structure
+```
+src/
+  data/
+    loaders/           # Feature store clients, dataset builders
+    preprocessing/
+  models/
+    baselines/
+    probabilistic/
+    deep_learning/
+    ensembles/
+  training/
+    pipelines/
+    tuning/
+  evaluation/
+    backtests/
+    metrics/
+  serving/
+    api/
+    batch/
+  utils/
+config/
+  experiments/
+  model_registry/
+notebooks/
+  research/
+  reports/
+```
+
+## Initial Milestones
+1. Stand up experiment tracking (MLflow) and baseline logistic regression / gradient boosting models.
+2. Implement calibration and profitability evaluation comparing predictions with bookmaker odds.
+3. Build automated training pipeline with hyperparameter tuning and artifact versioning.
+4. Deploy MVP prediction API returning win/draw/loss probabilities for selected leagues.
+5. Add goal distribution modeling to support over/under and Asian handicap markets.
+
+## Risk Management
+- **Overfitting**: Use time-based cross-validation, regularization, and model ensembling.
+- **Data Leakage**: Enforce strict temporal splits and feature freshness checks.
+- **Model Drift**: Monitor performance, trigger retraining workflows, maintain champion/challenger deployments.
+- **Explainability**: Provide SHAP summaries and natural language model cards for stakeholders.


### PR DESCRIPTION
## Summary
- scaffold the Python data-pipeline package with adapters, transformer, validations, and JSONL sink
- add a runnable sample ingestion CLI plus fixture dataset and unit tests exercising the pipeline
- document setup steps, quickstart instructions, and ignore transient build artifacts

## Testing
- python -m unittest discover -s tests